### PR TITLE
The ability to build new instances

### DIFF
--- a/src/main/java/nl/iobyte/jadi/JaDI.java
+++ b/src/main/java/nl/iobyte/jadi/JaDI.java
@@ -93,7 +93,7 @@ public class JaDI extends AnnotationProcessor {
     }
 
     /**
-     * Get new instance of type with parameters
+     * Get new instance of type with parameters.
      *
      * @param type   type
      * @param values parameters

--- a/src/main/java/nl/iobyte/jadi/JaDI.java
+++ b/src/main/java/nl/iobyte/jadi/JaDI.java
@@ -1,6 +1,7 @@
 package nl.iobyte.jadi;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
@@ -89,6 +90,28 @@ public class JaDI extends AnnotationProcessor {
         } catch (Exception e) {
             return null;
         }
+    }
+
+    /**
+     * Get new instance of type with parameters
+     *
+     * @param type   type
+     * @param values parameters
+     * @param <T>    type
+     * @return new type instance
+     */
+    public synchronized <T> T build(Type<T> type, Object... values) {
+        TypeFactory<T> factory = TypeFactory.of(type);
+        boolean b = factory.getDependencies().stream().allMatch(dependency -> {
+            if(hierarchyMap.containsKey(dependency))
+                return true;
+
+            return Arrays.stream(values).anyMatch(obj -> !dependency.noInstance(obj));
+        });
+        if(!b)
+            return null;
+
+        return factory.create(hierarchyMap::get, values);
     }
 
     /**

--- a/src/main/java/nl/iobyte/jadi/objects/HierarchyMap.java
+++ b/src/main/java/nl/iobyte/jadi/objects/HierarchyMap.java
@@ -23,29 +23,11 @@ public class HierarchyMap extends HashMap<Type<?>, Object> {
      * @return value
      */
     private Object getInternal(Type<?> type) {
-        Object value = super.get(type);
-        if(value != null)
-            return value;
+        type = getClosestType(type);
+        if(type == null)
+            return null;
 
-        // Get assignable keys
-        List<Type<?>> assignableKeys = keySet().stream()
-            .filter(type::isAssignable)
-            .toList();
-
-        int distance = Integer.MAX_VALUE;
-        Type<?> closestType = null;
-        for(Type<?> assignableKey : assignableKeys) {
-            int i = assignableKey.getHierarchyDepth(type);
-            if(i == -1)
-                continue;
-
-            if(i < distance) {
-                distance = i;
-                closestType = assignableKey;
-            }
-        }
-
-        return closestType == null ? null : super.get(closestType);
+        return super.get(type);
     }
 
     /**
@@ -59,6 +41,38 @@ public class HierarchyMap extends HashMap<Type<?>, Object> {
             return true;
 
         return keySet().stream().anyMatch(type::isAssignable);
+    }
+
+    /**
+     * Get the closest type found in map
+     *
+     * @param type type
+     * @return type
+     */
+    public Type<?> getClosestType(Type<?> type) {
+        if(super.containsKey(type))
+            return type;
+
+        // Get assignable keys
+        List<Type<?>> assignableKeys = keySet().stream()
+            .filter(type::isAssignable)
+            .toList();
+
+        // Get the closest type
+        int distance = Integer.MAX_VALUE;
+        Type<?> closestType = null;
+        for(Type<?> assignableKey : assignableKeys) {
+            int i = assignableKey.getHierarchyDepth(type);
+            if(i == -1)
+                continue;
+
+            if(i < distance) {
+                distance = i;
+                closestType = assignableKey;
+            }
+        }
+
+        return closestType;
     }
 
 }

--- a/src/main/java/nl/iobyte/jadi/objects/HierarchyMap.java
+++ b/src/main/java/nl/iobyte/jadi/objects/HierarchyMap.java
@@ -44,7 +44,7 @@ public class HierarchyMap extends HashMap<Type<?>, Object> {
     }
 
     /**
-     * Get the closest type found in map
+     * Get the closest type found in map.
      *
      * @param type type
      * @return type

--- a/src/main/java/nl/iobyte/jadi/reflections/TypeFactory.java
+++ b/src/main/java/nl/iobyte/jadi/reflections/TypeFactory.java
@@ -70,6 +70,34 @@ public class TypeFactory<T> {
     }
 
     /**
+     * Create a new instance of type with type resolves and parameters.
+     *
+     * @param typeResolver type -> instance resolver
+     * @param values       objects to use/prioritise for resolving
+     * @return new type instance
+     */
+    public T create(TypeResolver typeResolver, Object... values) {
+        return create(type -> {
+            int distance = Integer.MAX_VALUE;
+            Object closestValue = null;
+
+            for(Object value : values) {
+                Type<?> valueType = Type.of(value.getClass());
+                int i = valueType.getHierarchyDepth(type);
+                if(i == -1)
+                    continue;
+
+                if(i <= distance) {
+                    distance = i;
+                    closestValue = value;
+                }
+            }
+
+            return closestValue == null ? typeResolver.apply(type) : closestValue;
+        });
+    }
+
+    /**
      * Get type factory of type.
      *
      * @param type type

--- a/src/test/java/nl/iobyte/jadi/JaDITest.java
+++ b/src/test/java/nl/iobyte/jadi/JaDITest.java
@@ -3,6 +3,7 @@ package nl.iobyte.jadi;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import lombok.AllArgsConstructor;
 import nl.iobyte.jadi.processor.objects.DummyClass;
 import nl.iobyte.jadi.reflections.Type;
 import org.junit.jupiter.api.Assertions;
@@ -39,6 +40,50 @@ class JaDITest {
     void resolveFactory() {
         Assertions.assertDoesNotThrow(() -> jadi.resolve(Type.of(DummyClass.class), Duration.ofSeconds(1)));
         Assertions.assertNotNull(jadi.resolve(Type.of(DummyClass.class), Duration.ofSeconds(1)));
+    }
+
+    @Test
+    void buildNone() {
+        jadi.bind(Type.of(boolean.class), true);
+        jadi.bind(Type.of(String.class), "something");
+
+        DummyBuildClass instance = jadi.build(Type.of(DummyBuildClass.class));
+        Assertions.assertNotNull(instance);
+        Assertions.assertTrue(instance.b);
+        Assertions.assertEquals("something", instance.str);
+    }
+
+    @Test
+    void buildAll() {
+        DummyBuildClass instance = jadi.build(Type.of(DummyBuildClass.class), true, "something");
+        Assertions.assertNotNull(instance);
+        Assertions.assertTrue(instance.b);
+        Assertions.assertEquals("something", instance.str);
+    }
+
+    @Test
+    void buildPartial() {
+        jadi.bind(Type.of(boolean.class), true);
+        jadi.bind(Type.of(String.class), "none");
+        
+        DummyBuildClass instance = jadi.build(Type.of(DummyBuildClass.class), "something");
+        Assertions.assertNotNull(instance);
+        Assertions.assertTrue(instance.b);
+        Assertions.assertEquals("something", instance.str);
+    }
+
+    @Test
+    void buildFail() {
+        DummyBuildClass instance = jadi.build(Type.of(DummyBuildClass.class), "something");
+        Assertions.assertNull(instance);
+    }
+
+    @AllArgsConstructor
+    public static class DummyBuildClass {
+
+        private String str;
+        private boolean b;
+
     }
 
 }


### PR DESCRIPTION
Use `JaDI.build` to acquire a new instance (which is not saved for dependency injection) with optionally provided parameters and the default dependency resolving.